### PR TITLE
Feature/add environment variable email domain validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+EMAIL_DOMAIN=example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.csv
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "csv",
+ "dotenv",
  "reqwest",
  "rpassword",
  "serde",
@@ -130,6 +131,12 @@ checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.82"
 
 csv = "1.1.6"
+dotenv = "0.15.0"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ CLI tool to invite Slack channels of a workspace
 ```bash
 git clone git@github.com:sohey-dr/chinviter.git
 cd chinviter
+cp .env.sample .env
 cargo run -- -help
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,7 @@ fn set_up(args: Cli) -> Result<(), io::Error> {
                 // TODO: validationを実装
                 let email = get_user_info_from_slack(token.to_string());
                 if !email.ends_with(email_domain.unwrap()) {
+                    println!("email domain is not matched");
                     return Ok(());
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,56 @@ struct ConversationsListResponse {
     response_metadata: ResponseMetadata,
 }
 
+
+#[derive(Serialize, Deserialize)]
+struct UserInfoResponse {
+    ok: bool,
+    user: Vec<User>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct User {
+    id: String,
+    team_id: String,
+    name: String,
+    deleted: bool,
+    color: String,
+    real_name: String,
+    tz: String, // e.g. Asia/Tokyo
+    tz_label: String, // e.g. Pacific Daylight Time,
+    profile: Profile,
+    tz_offset: i32, // e.g. -25200,
+    is_admin: bool,
+    is_owner: bool,
+    is_primary_owner: bool,
+    is_restricted: bool,
+    is_ultra_restricted: bool,
+    is_bot: bool,
+    updated: i32, // TODO: UnixTime Only
+    is_app_user: bool,
+    has_2fa: bool
+}
+
+#[derive(Serialize, Deserialize)]
+struct Profile {
+        avatar_hash: String,
+        status_text: String,
+        status_emoji: String,
+        real_name: String,
+        display_name: String,
+        real_name_normalized: String,
+        display_name_normalized: String,
+        email: String, // TODO: email only validation
+        image_original: String, // TODO: URL only validations
+        image_24: String, // TODO: URL only validation
+        image_32: String, // TODO: URL only validation
+        image_48: String, // TODO: URL only validation
+        image_72: String, // TODO: URL only validation
+        image_192:String, // TODO: URL only validation
+        image_512:String, // TODO: URL only validation
+        team: String
+}
+
 #[derive(Serialize, Deserialize)]
 struct Channel {
     id: String,
@@ -74,6 +124,16 @@ fn get_request_slack_api(method: &str, token: &str) -> reqwest::blocking::Respon
         .send();
 
     return resp.unwrap();
+}
+
+// https://api.slack.com/methods/users.info
+fn get_user_info_from_slack(token: &str) -> String {
+    let path = format!("users.info");
+    let json_str = get_request_slack_api(&path, token);
+    let res: UserInfoResponse = serde_json::from_str(&json_str.text().unwrap()).unwrap();
+    let mut records: Vec<Vec<String>> = Vec::new();
+
+    res.user.profile.email;
 }
 
 fn get_channels_from_slack(token: &str, next_cursor: String) -> (Vec<Vec<String>>, String) {
@@ -193,7 +253,8 @@ fn delete_invite_targets_csv() -> Result<(), io::Error> {
 }
 
 fn set_up(args: Cli) -> Result<(), io::Error> {
-    let token = get_token();
+    // let token = get_token();
+    let token = "aaa".to_string();
 
     let mut sp = Spinner::new(Spinners::Dots9, "".into());
     match args.subcommand.as_str() {
@@ -204,6 +265,18 @@ fn set_up(args: Cli) -> Result<(), io::Error> {
             if args.user_id == "" {
                 println!("user_id is required");
                 return Ok(());
+            }
+
+            let email_domain = option_env!("EMAIL_DOMAIN");
+            println!("email_domain is set to {:?}", email_domain);
+
+            if !email_domain.is_none() {
+                // TODO: validationを実装
+                let email = get_user_info_from_slack(token);
+                if !email.ends_with(email_domain.unwrap()) {
+                    println!("{} is not in {}", email, email_domain);
+                    return Ok(());
+                }
             }
 
             duplicate_conversations_csv()?;


### PR DESCRIPTION
## General

Introduce a mechanism to prevent only specific domains to prevent mistakes. If the domain of the user to be invited is other than the domain set in the environment variable, the invitation will not be made.

## Precondition

email is required. but to get user.profile.email is required "The [users:read.email](https://api.slack.com/scopes/users:read.email) OAuth scope"

↓Slack Documentation

> The [users:read.email](https://api.slack.com/scopes/users:read.email) OAuth scope is now required to access the email field in [user objects](https://api.slack.com/types/user) returned by the [users.list](https://api.slack.com/methods/users.list) and [users.info](https://api.slack.com/methods/users.info) web API methods. [users:read](https://api.slack.com/scopes/users:read) is no longer a sufficient scope for this data field. [Learn more](https://api.slack.com/changelog/2017-04-narrowing-email-access).